### PR TITLE
Added ability for multipart last names and city names

### DIFF
--- a/src/main/java/com/samgauck/CityManagement/Main.java
+++ b/src/main/java/com/samgauck/CityManagement/Main.java
@@ -199,7 +199,7 @@ public class Main {
             command.execute(input);
         }
         System.out.print("Please enter a name for your city: ");
-        input = s.next();
+        input = s.nextLine(); //Originally next() which did not allow for two word cities like Las Vegas, Las Angeles, New Mexico, etc.
         input = Utilities.removeProfanity(input);
         cities.add(new City(input)); //creates new city with your name
         cities.get(0).resources.setMoney(100_000);
@@ -211,14 +211,14 @@ public class Main {
             String first = s.next();
             first = Utilities.removeProfanity(first);
             System.out.println("What is the man's last name?");
-            String last = s.next();
+            String last = s.nextLine(); //Originally next() which did not allow for multi part last names like Di Vinci, Delano Roosevelt
             last = Utilities.removeProfanity(last);
             cities.get(0).nameCitizen(0, first, last);
             System.out.println("What is the woman's first name?");
             first = s.next();
             first = Utilities.removeProfanity(first);
             System.out.println("What is the woman's last name?");
-            last = s.next();
+            last = s.nextLine(); //Originally next() which did not allow for multi part last names like Di Vinci, Delano Roosevelt
             last = Utilities.removeProfanity(last);
             cities.get(0).nameCitizen(1, first, last);
         } else {

--- a/src/main/java/com/samgauck/CityManagement/Main.java
+++ b/src/main/java/com/samgauck/CityManagement/Main.java
@@ -199,7 +199,7 @@ public class Main {
             command.execute(input);
         }
         System.out.print("Please enter a name for your city: ");
-        input = s.nextLine(); //Originally next() which did not allow for two word cities like Las Vegas, Las Angeles, New Mexico, etc.
+        input = s.nextLine(); //Originally next() which did not allow for two word cities like Las Vegas, Los Angeles, New Mexico, etc.
         input = Utilities.removeProfanity(input);
         cities.add(new City(input)); //creates new city with your name
         cities.get(0).resources.setMoney(100_000);


### PR DESCRIPTION
Previously next() was being used, which caused the bug of not being able to choose if you want to name the citizens or not if a multipart name was used for the city.  Changed to nextLine() for city name and last name.  First names still have this issue, but I do not know if the names should be allowed to be multipart or if the buffer should just be cleared.